### PR TITLE
Add example services

### DIFF
--- a/examples/notif.py
+++ b/examples/notif.py
@@ -16,10 +16,23 @@
 #
 # -*- coding: utf-8 -*-
 
-from pluggy import HookimplMarker, PluginManager
+import json
 
-hookimpl = HookimplMarker('mqsf')
-"""Marker to be imported and used in plugins (and for own implementations)"""
+from mqsf.main import main
+from mqsf import hookimpl, plugin_manager
 
-plugin_manager = PluginManager('mqsf')
-"""PM to be be imported and used to register plugins"""
+
+class EmailPlugin(object):
+    @hookimpl
+    def run_task(self, data, log_callback):
+        """Send email notification with Wx data"""
+        wx_info = data['wx_data']
+        print(json.dumps(wx_info))
+
+
+def run():
+    plugin_manager.register(EmailPlugin, 'email')
+    main('notif')
+
+
+run()

--- a/examples/notif_config.yaml
+++ b/examples/notif_config.yaml
@@ -1,0 +1,5 @@
+mq_user: user
+mq_pass: password
+previous_service: wx
+plugin_key: notification_type
+no_op_okay: false

--- a/examples/wx.py
+++ b/examples/wx.py
@@ -38,8 +38,8 @@ class CurrentPlugin(object):
     def run_task(self, data, log_callback):
         """Get current Wx for given location"""
         data['wx_data'] = {
-            'Temp': '15C',
-            'Humidity': '56%'
+            'Temp': '22C',
+            'Humidity': '34%'
         }
 
 

--- a/examples/wx.py
+++ b/examples/wx.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023 SUSE LLC.  All rights reserved.
+#
+# This file is part of mqsf.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -*- coding: utf-8 -*-
+
+from mqsf.main import main
+from mqsf import hookimpl, plugin_manager
+
+
+class ForecastPlugin(object):
+    @hookimpl
+    def run_task(self, data, log_callback):
+        """Get Wx forecast for given location"""
+        data['wx_data'] = {
+            'Tomorrow': {
+                'High Temp': '15C',
+                'Low Temp': '10C',
+                'Humidity': '56%'
+            }
+        }
+
+
+class CurrentPlugin(object):
+    @hookimpl
+    def run_task(self, data, log_callback):
+        """Get current Wx for given location"""
+        data['wx_data'] = {
+            'Temp': '15C',
+            'Humidity': '56%'
+        }
+
+
+def run():
+    plugin_manager.register(ForecastPlugin, 'forecast')
+    plugin_manager.register(CurrentPlugin, 'current')
+    main('wx')
+
+
+run()

--- a/examples/wx_config.yaml
+++ b/examples/wx_config.yaml
@@ -1,0 +1,5 @@
+mq_user: user
+mq_pass: password
+previous_service: user
+plugin_key: data_type
+no_op_okay: false

--- a/mqsf/config/base_config.py
+++ b/mqsf/config/base_config.py
@@ -150,3 +150,10 @@ class BaseConfig(object):
             attribute='base_thread_pool_count'
         )
         return base_thread_pool_count or Defaults.get_base_thread_pool_count()
+
+    def get_plugin_key(self):
+        """
+        Return the plugin key name to use for determining what plugin to run.
+        """
+        plugin_key = self._get_attribute(attribute='plugin_key')
+        return plugin_key or 'plugin'

--- a/mqsf/hookspecs.py
+++ b/mqsf/hookspecs.py
@@ -22,6 +22,7 @@ import pluggy
 hookspec = pluggy.HookspecMarker('mqsf')
 
 
-@hookspec
-def run_task(job_config, log_callback):
-    """Run the workload"""
+class MQSFSpec(object):
+    @hookspec
+    def run_task(self, data, log_callback):
+        """Run the workload"""

--- a/mqsf/no_op_job.py
+++ b/mqsf/no_op_job.py
@@ -20,6 +20,6 @@ from mqsf import hookimpl
 
 
 @hookimpl
-def run_task(job_config, log_callback):
+def run_task(data, log_callback):
     """Run the workload"""
     return


### PR DESCRIPTION
- Add plugin_key option to config
- Convert spec to class based to allow for single module plugins
- Move plugin_manager instance to an importable namespace
- Rename job_config arg in spec to data to be more generic